### PR TITLE
Super basic support for Windows Python

### DIFF
--- a/lib/rubypython/pythonexec.rb
+++ b/lib/rubypython/pythonexec.rb
@@ -71,6 +71,19 @@ class RubyPython::PythonExec
       locations << File.join(path, "#{base}.dll")   # Windows
       locations << File.join(path, "#{base}.a")     # Non-DLL
     end
+    
+    if FFI::Platform.windows?
+      # Do this after trying to add alternative extensions, 
+      # since windows install has a python27.a and can cause 
+      # troble. FFI fails at guessing pythons directory and libs.
+      # Find the windows lib by looking in the libs directory
+      # where the python exe is located.
+      path = File.dirname(@python)
+      # Windows Python doesn't like ' with inner " so we have to switch it around. 
+      winversion = %x(#{@python} -c "import sys; print '%d%d' % sys.version_info[:2]").chomp
+      locations << File.join(path, "python#{winversion}.dll")
+      locations << File.join(path, "libs", "python#{winversion}.dll")
+    end
 
     # Remove redundant locations
     locations.uniq!


### PR DESCRIPTION
Prefix. I have never written a line of Ruby before so please fix/improve where needed.

Super basic support, this doesn't clean up the errors from the Windows Python not liking the order of quote when being called. It wants " then ' 

This does allow windows users to get by.

I'm not very familiar with Bitbucket or Hg so I hope you don't mind my use of GitHub and Git. 
